### PR TITLE
gerrit: cast change and patchset numbers to str

### DIFF
--- a/zuul/driver/gerrit/gerritconnection.py
+++ b/zuul/driver/gerrit/gerritconnection.py
@@ -477,6 +477,7 @@ class GerritConnection(BaseConnection):
             change.is_current_patchset = True
         else:
             change.is_current_patchset = False
+        self.log.debug("Updating %s: is_current_patchset %s, max_ps %s (%s), patchset %s (%s)" % (change, change.is_current_patchset, max_ps, type(max_ps), change.patchset, type(change.patchset),))
         change.files = files
 
         change.is_merged = self._isMerged(change)

--- a/zuul/driver/gerrit/gerritconnection.py
+++ b/zuul/driver/gerrit/gerritconnection.py
@@ -81,7 +81,7 @@ class GerritEventConnector(threading.Thread):
             event.change_url = change.get('url')
             patchset = data.get('patchSet')
             if patchset:
-                event.patch_number = patchset.get('number')
+                event.patch_number = str(patchset.get('number'))
                 event.ref = patchset.get('ref')
             event.approvals = data.get('approvals', [])
             event.comment = data.get('comment')
@@ -379,6 +379,9 @@ class GerritConnection(BaseConnection):
         return change
 
     def _getChange(self, number, patchset, refresh=False, history=None):
+        # Ensure number and patchset are str
+        number = str(number)
+        patchset = str(patchset)
         change = self._change_cache.get(number, {}).get(patchset)
         if change and not refresh:
             return change
@@ -427,7 +430,8 @@ class GerritConnection(BaseConnection):
                 result['commitMessage']):
                 if match != change_id:
                     continue
-                key = (result['number'], result['currentPatchSet']['number'])
+                key = (str(result['number']),
+                       str(result['currentPatchSet']['number']))
                 if key in seen:
                     continue
                 self.log.debug("Updating %s: Found change %s,%s "
@@ -454,8 +458,7 @@ class GerritConnection(BaseConnection):
         change._data = data
 
         if change.patchset is None:
-            change.patchset = data['currentPatchSet']['number']
-
+            change.patchset = str(data['currentPatchSet']['number'])
         if 'project' not in data:
             raise exceptions.ChangeNotFound(change.number, change.patchset)
         change.project = self.source.getProject(data['project'])
@@ -464,12 +467,12 @@ class GerritConnection(BaseConnection):
         max_ps = 0
         files = []
         for ps in data['patchSets']:
-            if ps['number'] == change.patchset:
+            if str(ps['number']) == change.patchset:
                 change.ref = ps['ref']
                 for f in ps.get('files', []):
                     files.append(f['file'])
             if int(ps['number']) > int(max_ps):
-                max_ps = ps['number']
+                max_ps = str(ps['number'])
         if max_ps == change.patchset:
             change.is_current_patchset = True
         else:
@@ -509,8 +512,8 @@ class GerritConnection(BaseConnection):
 
         for record in self._getDependsOnFromCommit(data['commitMessage'],
                                                    change):
-            dep_num = record['number']
-            dep_ps = record['currentPatchSet']['number']
+            dep_num = str(record['number'])
+            dep_ps = str(record['currentPatchSet']['number'])
             self.log.debug("Updating %s: Getting commit-dependent "
                            "change %s,%s" %
                            (change, dep_num, dep_ps))
@@ -531,8 +534,8 @@ class GerritConnection(BaseConnection):
                     needed_by_changes.append(dep)
 
         for record in self._getNeededByFromCommit(data['id'], change):
-            dep_num = record['number']
-            dep_ps = record['currentPatchSet']['number']
+            dep_num = str(record['number'])
+            dep_ps = str(record['currentPatchSet']['number'])
             self.log.debug("Updating %s: Getting commit-needed change %s,%s" %
                            (change, dep_num, dep_ps))
             # Because a commit needed-by may be a cross-repo


### PR DESCRIPTION
We need to cast all json access to change and patchset number
as str. At least the refresh_deps logic relies on python eq check,
and Zuul doesn't dequeue child changes when parent change get
updated in Gerrit-2.14.

Here is diagnostic DEBUG informations
(2 depends-on 1, patchset 1,13 doesn't dequeue change 2):

Change <Change 1,13> is a new version of <Change 1,12>,
  removing <QueueItem for <Change 1,12> in check>
Canceling builds behind change: <Change 1,12> because it is being removed.
Cancel jobs for change <Change 1,12>
Removing change <Change 1,12> from queue
[snip]
Starting queue processor: check
Checking for changes needed by <Change 2,5>:
  Change <Change 2,5> needs change <Change 1,12>:
  Needed change is already ahead in the queue

Backport of Change-Id Id73a479d155fa6d9b2c562869cae6c82dd065911
without changes to zuul/driver/gerrit/gerritsource.py.